### PR TITLE
Remove old style definitions after style merges to prevent later style shadowing

### DIFF
--- a/ooopy/Transforms.py
+++ b/ooopy/Transforms.py
@@ -928,6 +928,8 @@ class Concatenate (_Body_Concat) :
         pb   = Addpagebreak \
             (stylename = self.pbname, transformer = self.transformer)
         self.divide_body (self.trees ['content.xml'][0])
+        tr   = self._attr_rename (0)
+        tr.apply (self.bodyparts)
         self.body_decl (self.declarations, append = 0)
         for idx in range (1, len (self.docs) + 1) :
             meta    = self.trees ['meta.xml'][idx]
@@ -1124,8 +1126,8 @@ class Concatenate (_Body_Concat) :
         for idx in range (len (self.trees [oofile])) :
             namemap = self.namemaps [idx]
             root    = self.trees    [oofile][idx]
-            delnode = []
             for nodeidx, node in enumerate (root) :
+                delnode = []
                 if node.tag not in self.style_containers :
                     continue
                 prefix = ''
@@ -1133,7 +1135,7 @@ class Concatenate (_Body_Concat) :
                 if node.tag == self.font_decls_tag :
                     prefix = oofile
                 default_style = None
-                for n in node :
+                for subnodeidx, n in enumerate (node) :
                     if  (   n.tag == self.oootag ('style', 'default-style')
                         and (  n.get (self.oootag ('style', 'family'))
                             == 'paragraph'
@@ -1166,8 +1168,7 @@ class Concatenate (_Body_Concat) :
                             namemap [key][name] = newname
                             # optimize original doc: remove duplicate styles
                             if  not idx and node.tag != self.font_decls_tag :
-                                pass
-                                #delnode.append (nodeidx)
+                                delnode.append (subnodeidx)
                     else :
                         newname = self._newname (key, name)
                         self.serialised [sn] = newname


### PR DESCRIPTION
This pull request addresses a concatenation problem that occurs when a style in the first document is renamed but the original style declaration is not deleted from the xml tree. If a subsequent document uses the same style *name*, the not-deleted original definition shadows the new definition, and elements are rendered using the obsolete style from the first document rather than the new style from the subsequent document. (It's confusing to put into words. The included odts should make the situation clearer.)

Description of files included in [style_shadowing.zip](https://github.com/schlatterbeck/OOoPy/files/10903749/style_shadowing.zip):

  - concat_a.odt, concat_b.odt: two source OOo documents for demonstrating the 
                                problem

  - unpatched/ : folder containing outputs from the unpatched version of ooopy
            - ab.odt: output of $ ooo_cat -o ab.odt concat_a.odt concat_b.odt
            - ba.odt: output of $ ooo_cat -o ba.odt concat_b.odt concat_a.odt
            - ab.pdf: pdf rendering of ab.odt (for convenience)
            - ba.pdf: pdf rendering of ba.pdf (for convenience)

  - patched/ : folder containing outputs from a patched version of ooopy; files correspond the versions in folder "unpatched"


concat_a.odt and concat_b.odt are constructed so that when concatenated in the order a-b, the third style in document A will shadow the third style in document B. When the documents are concatenated in the opposite order, no shadowing occurs. The rendered style of text each line in those documents should match the textual description in the line. (Eg. if the line says "I am in italics", the text should be rendered in italics.)

The defect behavior is evident by looking at the difference between unpatched/ab.odt and unpatched/ba.odt (or the pdf versions). In the a-b order, the last line of document B has the wrong style applied, because it is being shadowed by style P4 from document A. Examining content.xml for ab.odt will show there are two styles named P4 in the style declarations; Open/LibreOffice takes the first one as the "correct" definition and ignores any re-definitions.

The PR fixes this behavior by first deleting renamed styles from the content tree during Concatenate.style_merge(), then by assuring that the style-renaming transform associated with the first document is actually applied to the body tree of that document in Concatenate.body_concat().
